### PR TITLE
Add instant run functionality

### DIFF
--- a/lib/dashboard/src/components/Block/OpenAI/Chat/sideBarData.js
+++ b/lib/dashboard/src/components/Block/OpenAI/Chat/sideBarData.js
@@ -2,6 +2,7 @@ import {React} from 'react'
 import { Form } from 'react-bootstrap';
 import CustomAlert from '../../../Extras/CustomAlert';
 import LLMToolCalling from '../../LLMToolCalling';
+import { InstantRun } from '../../../InstantRuns/InstantRun';
 
 const OpenAIChatSideBarData = ({sideBarData, onDataChange}) => {
   return (
@@ -37,6 +38,8 @@ const OpenAIChatSideBarData = ({sideBarData, onDataChange}) => {
         </Form.Group>
         <hr/>
         <LLMToolCalling onDataChange={onDataChange} tools={sideBarData}/>
+        <hr/>
+        <InstantRun blockData={sideBarData} />
     </div>
   )
 }

--- a/lib/dashboard/src/components/InstantRuns/InstantRun.js
+++ b/lib/dashboard/src/components/InstantRuns/InstantRun.js
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { Form, Button } from 'react-bootstrap';
+import { Formik, Field } from 'formik';
+import { createRunConfigForNode } from '../Workflows/Utils/CreateRunConfig';
+import { JsonView, allExpanded, defaultStyles } from 'react-json-view-lite';
+
+const instantRunBlock = async (
+    runConfig,
+    coreBlockType,
+    processType,
+    payload
+) => {
+    try {
+        const response = await fetch('http://localhost:8000/instant_run', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                run_config: runConfig,
+                core_block_type: coreBlockType,
+                process_type: processType,
+                payload: payload
+            })
+        });
+        return response
+    } catch (error) {
+        return error
+    }
+}
+
+/**
+ * InstantRun is a component that enables users to test a block's 
+ * output. Users should be able to use this component with any block
+ * that they want to immediately test.
+ *
+ * @param {{ blockData: object }} props - The props for the component.
+ */
+export const InstantRun = ({ blockData }) => {
+    const [runResponse, setRunResponse] = useState(null);
+
+  const handleButtonClick = async (values) => {
+    const runConfig = createRunConfigForNode(blockData);
+    const coreBlockType = blockData.core_block_type;
+    const processType = blockData.process_type;
+    const payload = values.payload;
+    // make a post request to the backend
+    const response = await instantRunBlock(
+        runConfig, 
+        coreBlockType, 
+        processType, 
+        payload
+    );
+    if (response.ok) {
+        const resp = await response.json();
+        setRunResponse(JSON.stringify(resp, null, 2));
+    }
+  };
+
+  return (
+    <>
+        <p style={{marginBottom: '20px', fontWeight: '500', fontSize: '22px'}}>Preview</p>
+        <Formik
+        initialValues={{ payload: '' }}
+        onSubmit={() => {}}
+        >
+        {({ handleChange, values }) => (
+            <>
+            <Form.Group className="form-group" controlId="formResourceType">
+                <Form.Label>Payload</Form.Label>
+                <Field
+                as="textarea"
+                name="payload"
+                rows={3}
+                className="form-control"
+                onChange={handleChange}
+                value={values.payload}
+                />
+            </Form.Group>
+            <Button 
+                type="button" 
+                onClick={() => handleButtonClick(values)}
+                style={{width: '100%'}}>
+                Test
+            </Button>
+            </>
+        )}
+        </Formik>
+        <div style={{marginTop: '25px'}}>
+            {runResponse && 
+            (
+                <>
+                    <p style={{marginBottom: '20px', fontWeight: '500', fontSize: '20px'}}>Output</p>
+                    <JsonView 
+                        data={JSON.parse(runResponse)} 
+                        shouldExpandNode={allExpanded} 
+                        style={defaultStyles} 
+                    />
+                </>
+            )}
+        </div>
+    </>
+  );
+};

--- a/lib/src/app/routers/instant_run_router.py
+++ b/lib/src/app/routers/instant_run_router.py
@@ -1,0 +1,45 @@
+import json
+import tempfile
+import os
+import shutil
+
+import docker
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from tasks.implementer import Implementer
+from integrations.implementer import IntegrationImplementer
+
+
+router = APIRouter()
+
+class InstantRunPayload(BaseModel):
+    payload: str
+    core_block_type: str
+    process_type: str
+    run_config: dict
+
+@router.post("/instant_run", tags=["Instant Runs"])
+def instant_run(request: InstantRunPayload):
+    """
+    Router for users to test instant runs. Should initialize
+    an Implementer, and then run and return the results back.
+    """
+    run_config = request.run_config
+    core_block_type = request.core_block_type
+    process_type = request.process_type
+    if process_type == 'task':
+        process = Implementer().create_task(
+            task_type=core_block_type, 
+            run_config=run_config
+        )
+    elif process_type == 'integration':
+        process = IntegrationImplementer().create_integration(
+            integration_type=core_block_type, 
+            run_config=run_config
+        )
+    else:
+        raise ValueError(f"Core block type {core_block_type} is not supported")
+    
+    response = process.run(request.payload)
+    return response

--- a/lib/src/client.py
+++ b/lib/src/client.py
@@ -14,7 +14,8 @@ from app.routers import (
     block_types_router,
     function_call_router,
     auth_router,
-    lambdas_router
+    lambdas_router,
+    instant_run_router
 )
 
 # TODO Refactor code so that things that do not need to be here, arent here.
@@ -74,3 +75,4 @@ app.include_router(block_types_router.router)
 app.include_router(function_call_router.router)
 app.include_router(auth_router.router)
 app.include_router(lambdas_router.router)
+app.include_router(instant_run_router.router)


### PR DESCRIPTION
This PR would be start of allowing users to instantly run a block prior to creating a workflow. Useful for seeing what the response will look like that can be used with the Lambda function.

With this PR, users can instantly run only the OpenAI block. Further integrations with all other blocks are underway.