### PR TITLE
Issue 73 dockerize the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,26 +28,70 @@ This project is still in its early phase. What will make this platform successfu
 ## 🚀 Getting Started
 
 ### Prerequisite: 
-1. Make sure to have Docker or Docker Desktop Installed on your computer.
-2. In order to run Ollama blocks, make sure you have the Ollama server running in the background. 
-3. Ensure you have poetry installed in your system:
-```
-curl -sSL https://install.python-poetry.org | python3 -
-```
-Once installation is complete, make sure to export poetry to PATH. This instruction should appear once you install poetry via the command above.
-
-4. This project was built using Python `3.11.4`, and it is recommended that you run it on the same version but you can also run this with versions `>=3.10,<3.13`. In case of any hiccups, please raise an [issue](https://github.com/farhan0167/otto-m8/issues).
+1. Clone the repository
+    ```bash
+    git clone https://github.com/farhan0167/otto-m8.git
+    cd otto-m8/
+    ```
+2. Make sure to have Docker or Docker Desktop Installed on your computer.
+3. In order to run Ollama blocks, make sure you have the Ollama server running in the background. 
 
 ### Run the project
 1. Run the following command to make `run.sh` executable
-```bash
-chmod +x run.sh
-```
-2. Then launch the application:
-```bash
-./run.sh
-```
-This should launch both the dashboard and the server. To access the dashboard, head over to `http://localhost:3000/`. Use the default login credentials to access the dashboard, and get started on your first workflow.
+   ```bash
+   chmod +x run.sh
+   ```
+2. **Lauching the application**
+    Once the script has the right permissions, you'll then need to run the `run.sh` script. This script will build all the necessary docker containers, including that of the frontend and backend. Since the server is hosted on a docker container, in order to deploy workflow containers, you'll need to mount your docker daemon to the server container which will allow the server to launch containers. You will therefore have two ways to launch:
+
+    1. **Without mounting** the docker daemon. This will mean that you won't be able to deploy your workflows as a docker container but you can still interact with it(build workflows and testing them). Similarly, you won't be able to launch Lambdas but you should still be able to modify or create custom blocks. To run:
+        ```bash
+        ./run.sh
+        ```
+    2. **Mounting** the docker daemon. This will mean that you will be able to deploy your workflows as docker containers and similarly be able to launch Lambdas. To run:
+        ```bash
+        ./run.sh --launch-containers
+        ```
+3. This script should launch all the containers necessary to get started with otto-m8. You can start interacting with the platform by heading to `http://localhost:3000`, once the FastAPI server started completely. You should look at something like this in your logs:
+      ```
+      Otto Dashboard URL: http://localhost:3000
+      Otto Server URL: http://localhost:8000
+      INFO:     Will watch for changes in these directories: ['/app']
+      INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
+      INFO:     Started reloader process [1] using StatReload
+      INFO:     Started server process [13]
+      INFO:     Waiting for application startup.
+      INFO:     Application startup complete.
+      ```
+4. **Debugging common issues**:
+    <details>
+    <summary>Error getting credentials</summary>
+    <p>This error is typically related to Docker credentials, and would look something like this:<p>
+
+    ```
+    error getting credentials - err: exit status 1, out: ``
+    Building slim base image...
+    [+] Building 0.2s (1/2)                                    docker:desktop-linux
+    [+] Building 0.2s (2/2) FINISHED                           docker:desktop-linux
+    => [internal] load build definition from slim-base.Dockerfile             0.0s
+    => => transferring dockerfile: 95B                                        0.0s
+    => ERROR [internal] load metadata for docker.io/library/python:3.11.4-sl  0.2st
+    ------
+    > [internal] load metadata for docker.io/library/python:3.11.4-slim:
+    ------
+    slim-base.Dockerfile:1
+    --------------------
+      1 | >>> FROM python:3.11.4-slim
+      2 |
+      3 |     RUN pip install otto-m8
+    --------------------
+    ERROR: failed to solve: python:3.11.4-slim: failed to resolve source metadata for docker.io/library/python:3.11.4-slim: error getting credentials - err: exit status 1, out: ``
+        
+    ```
+
+    To solve this simply run `rm ~/.docker/config.json` as mention in this [post](https://stackoverflow.com/questions/71770693/error-saving-credentials-error-storing-credentials-err-exit-status-1-out).
+    </details>
+
 
 ## 🛠️ Documentation
 Please see [here](https://otto-m8.com/) for full documentation, including:

--- a/lib/dashboard/Dockerfile
+++ b/lib/dashboard/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:16-alpine
+
+WORKDIR /app
+
+COPY . /app
+
+# Install dependencies
+RUN npm install
+
+ARG CAN_DEPLOY_WORKFLOW
+RUN echo Can deploy workflow: $CAN_DEPLOY_WORKFLOW
+ENV REACT_APP_CAN_DEPLOY_WORKFLOW=$CAN_DEPLOY_WORKFLOW
+
+
+# Expose env vars at runtime
+CMD ["npm", "start"]

--- a/lib/dashboard/src/components/Pages/Lambdas/LambdasPage.js
+++ b/lib/dashboard/src/components/Pages/Lambdas/LambdasPage.js
@@ -15,6 +15,8 @@ import { CodeEditor } from './CodeEditor';
 
 import CustomAlert from '../../Extras/CustomAlert';
 
+const canDeployContainers = process.env.REACT_APP_CAN_DEPLOY_WORKFLOW
+
 const LambdasPage = () => {
     // All available lambda functions:
     const [data, setData] = useState([]);
@@ -266,37 +268,44 @@ const LambdaModal = ({
         }
       </Modal.Header>
       <Modal.Body>
-        <div style={{marginBottom: '30px'}}>
-            <Row>
-                <Col style={{display: 'flex', justifyContent: 'flex-start'}}>
-                    <Form style={{width: '100%', marginBottom: '0px'}}>
-                    <Form.Group className='form-group' controlId="formBasicEmail" style={{marginBottom: '0px'}}>
-                        <Form.Control 
-                            type="text" 
-                            placeholder="Enter Lambda Name"
-                            value={lambdaName}
-                            onBlur={(e) => setLambdaName(e.target.value)}
-                            onChange={onLambdaNameChange}
-                        />
-                    </Form.Group>
-                    {/* Conditionally render the CustomAlert if there's an invalid character */}
-                    {showAlert && (
-                        <CustomAlert
-                        alertText="Lambda name cannot contain spaces, commas, backslashes, or single quotes."
-                        level="danger"
-                        dismissible={false}
-                        />
-                    )}
-                    </Form>
-                </Col>
-                <Col style={{display: 'flex', justifyContent: 'flex-end', height: '100%'}}>
-                    {lambdaId ? 
-                        <Button variant="primary" onClick={onDeploy}>Re-Deploy</Button> :
-                        <Button variant="primary" onClick={onDeploy}>Deploy</Button>
-                    }
-                </Col>
-            </Row>
-        </div>
+        {canDeployContainers ?  (<div style={{marginBottom: '30px'}}>
+              <Row>
+                  <Col style={{display: 'flex', justifyContent: 'flex-start'}}>
+                      <Form style={{width: '100%', marginBottom: '0px'}}>
+                      <Form.Group className='form-group' controlId="formBasicEmail" style={{marginBottom: '0px'}}>
+                          <Form.Control 
+                              type="text" 
+                              placeholder="Enter Lambda Name"
+                              value={lambdaName}
+                              onBlur={(e) => setLambdaName(e.target.value)}
+                              onChange={onLambdaNameChange}
+                          />
+                      </Form.Group>
+                      {/* Conditionally render the CustomAlert if there's an invalid character */}
+                      {showAlert && (
+                          <CustomAlert
+                          alertText="Lambda name cannot contain spaces, commas, backslashes, or single quotes."
+                          level="danger"
+                          dismissible={false}
+                          />
+                      )}
+                      </Form>
+                  </Col>
+                  <Col style={{display: 'flex', justifyContent: 'flex-end', height: '100%'}}>
+                      {lambdaId ? 
+                          <Button variant="primary" onClick={onDeploy}>Re-Deploy</Button> :
+                          <Button variant="primary" onClick={onDeploy}>Deploy</Button>
+                      }
+                  </Col>
+              </Row>
+          </div>): (
+            <div style={{marginBottom: '30px'}}>
+                <CustomAlert 
+                alertText="Launching lambdas require deploying Docker containers, and based on your current configuration, this feature is not available." 
+                level="danger" 
+                dismissible={false} 
+                />
+            </div>)}
         <CodeEditor code={code} setCode={setCode}/>
       </Modal.Body>
     </Modal>

--- a/lib/dashboard/src/components/Pages/Lambdas/LambdasPage.js
+++ b/lib/dashboard/src/components/Pages/Lambdas/LambdasPage.js
@@ -268,7 +268,7 @@ const LambdaModal = ({
         }
       </Modal.Header>
       <Modal.Body>
-        {canDeployContainers ?  (<div style={{marginBottom: '30px'}}>
+        {canDeployContainers===true ?  (<div style={{marginBottom: '30px'}}>
               <Row>
                   <Col style={{display: 'flex', justifyContent: 'flex-start'}}>
                       <Form style={{width: '100%', marginBottom: '0px'}}>

--- a/lib/dashboard/src/components/Pages/Workflows/Workflow.js
+++ b/lib/dashboard/src/components/Pages/Workflows/Workflow.js
@@ -590,7 +590,7 @@ export default function Flow() {
                   <Stack variant="outlined" aria-label="Loading button group" direction="row" spacing={1} sx={{height: '40px'}}>
                       <Button id='add-block-button' color='primary' variant='contained' sx={{width: '120px'}} onClick={addNodeButtonClick} size='medium'>Add Block</Button>
                       <Button color='primary' variant='contained' sx={{width: '160px'}} onClick={handleShowTestWorkflow} size='medium'>Test Workflow</Button>
-                      {canDeployWorkflow && <Button color='primary' variant='contained' sx={{width: '120px'}} onClick={handleRunWorkflowButton} size='medium'>Deploy</Button>}
+                      {canDeployWorkflow===true && <Button color='primary' variant='contained' sx={{width: '120px'}} onClick={handleRunWorkflowButton} size='medium'>Deploy</Button>}
                       <Tooltip title='Save Draft'>
                         <Button onClick={handleDraftSave} variant='outlined' sx={{minWidth: '40px', width: '45px', padding: '0px'}}>
                           <TfiSave size={20} className='template-action'/>

--- a/lib/dashboard/src/components/Pages/Workflows/Workflow.js
+++ b/lib/dashboard/src/components/Pages/Workflows/Workflow.js
@@ -84,6 +84,8 @@ const initialEdges = [
   { id: 'e2-3', source: '2', target: '3', animated: true },
 ];
 
+const canDeployWorkflow = process.env.REACT_APP_CAN_DEPLOY_WORKFLOW;
+
 export default function Flow() {
 
   const { token, logout } = useAuth();
@@ -588,7 +590,7 @@ export default function Flow() {
                   <Stack variant="outlined" aria-label="Loading button group" direction="row" spacing={1} sx={{height: '40px'}}>
                       <Button id='add-block-button' color='primary' variant='contained' sx={{width: '120px'}} onClick={addNodeButtonClick} size='medium'>Add Block</Button>
                       <Button color='primary' variant='contained' sx={{width: '160px'}} onClick={handleShowTestWorkflow} size='medium'>Test Workflow</Button>
-                      <Button color='primary' variant='contained' sx={{width: '120px'}} onClick={handleRunWorkflowButton} size='medium'>Deploy</Button>
+                      {canDeployWorkflow && <Button color='primary' variant='contained' sx={{width: '120px'}} onClick={handleRunWorkflowButton} size='medium'>Deploy</Button>}
                       <Tooltip title='Save Draft'>
                         <Button onClick={handleDraftSave} variant='outlined' sx={{minWidth: '40px', width: '45px', padding: '0px'}}>
                           <TfiSave size={20} className='template-action'/>

--- a/lib/docker-compose.privilleged.yml
+++ b/lib/docker-compose.privilleged.yml
@@ -41,6 +41,7 @@ services:
     working_dir: /app
     volumes:
       - ./otto_backend:/app
+      - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - 8000:8000
     networks:

--- a/lib/docker-compose.privilleged.yml
+++ b/lib/docker-compose.privilleged.yml
@@ -28,6 +28,7 @@ services:
     image: farhan0167/otto-m8-dashboard:latest
     volumes:
       - ./dashboard:/app
+      - /app/node_modules
     ports:
       - "3000:3000"
     networks:

--- a/lib/docker-compose.yml
+++ b/lib/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     image: farhan0167/otto-m8-dashboard:latest
     volumes:
       - ./dashboard:/app
+      - /app/node_modules
     ports:
       - "3000:3000"
     networks:

--- a/lib/otto_backend/base.Dockerfile
+++ b/lib/otto_backend/base.Dockerfile
@@ -6,6 +6,6 @@ COPY . /app
 
 RUN pip install poetry
 
-RUN poetry config virtualenvs.in-project true
+#RUN poetry config virtualenvs.in-project true
 
 RUN poetry install

--- a/lib/otto_backend/core/container_utils/docker_tools.py
+++ b/lib/otto_backend/core/container_utils/docker_tools.py
@@ -145,10 +145,11 @@ class DockerTools:
         Returns:
             docker.models.containers.Container: The started container.
         """
-        volumes = {
-            f'{mount_dir}/.cache': {'bind': '/root/.cache', 'mode': 'rw'},
-            f'{mount_dir}/implementations': {'bind': '/app/implementations', 'mode': 'rw'}
-        } if mount_dir else None
+        # volumes = {
+        #     f'{mount_dir}/.cache': {'bind': '/root/.cache', 'mode': 'rw'},
+        #     f'{mount_dir}/implementations': {'bind': '/app/implementations', 'mode': 'rw'}
+        # } if mount_dir else None
+        volumes = None
         client = docker.from_env()
         container = client.containers.run(
                 image=image_id,

--- a/lib/otto_backend/db/db_engine.py
+++ b/lib/otto_backend/db/db_engine.py
@@ -3,7 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import Column, Integer, String
 
-DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_HOST = os.getenv("DB_HOST", "postgres")
 SQLALCHEMY_DATABASE_URL = f"postgresql://postgres:123456@{DB_HOST}:5432/postgres"
 
 engine = create_engine(

--- a/lib/otto_backend/routers/dependency.py
+++ b/lib/otto_backend/routers/dependency.py
@@ -12,7 +12,7 @@ from db.models.users import Users
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
 
 # Redis connection
-token_store = Redis(host="localhost", port=6379, decode_responses=True)
+token_store = Redis(host="redis", port=6379, decode_responses=True)
 
 def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> Users:
     """Retrieve the current user based on the token."""

--- a/lib/otto_backend/server.Dockerfile
+++ b/lib/otto_backend/server.Dockerfile
@@ -1,0 +1,9 @@
+FROM farhan0167/otto-m8-base:latest
+
+WORKDIR /app
+
+EXPOSE 8000
+
+# Start the FastAPI server using Uvicorn
+RUN echo "Starting FastAPI server..."
+CMD ["poetry", "run", "uvicorn", "client:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/run.sh
+++ b/run.sh
@@ -25,7 +25,7 @@ done
 # Function to handle cleanup on keyboard interrupt
 cleanup() {
     echo "Caught interrupt signal. Stopping Docker Compose services..."
-    sudo docker compose down
+    docker compose down
     exit 0
 }
 
@@ -38,23 +38,23 @@ mkdir .cache
 
 
 echo "Building slim base image..."
-sudo docker build -f slim-base.Dockerfile -t farhan0167/otto-m8-slim-base:latest .
+docker build -f slim-base.Dockerfile -t farhan0167/otto-m8-slim-base:latest .
 
 echo "Building base image..."
-sudo docker build -f base.Dockerfile -t farhan0167/otto-m8-base:latest .
+docker build -f base.Dockerfile -t farhan0167/otto-m8-base:latest .
 
-sudo docker build -f server.Dockerfile -t farhan0167/otto-m8-server:latest .
+docker build -f server.Dockerfile -t farhan0167/otto-m8-server:latest .
 
 cd "../dashboard"
 
 echo "Building dashboard image..."
-sudo docker build -f Dockerfile -t farhan0167/otto-m8-dashboard:latest --build-arg CAN_DEPLOY_WORKFLOW=$CAN_DEPLOY_WORKFLOW .
+docker build -f Dockerfile -t farhan0167/otto-m8-dashboard:latest --build-arg CAN_DEPLOY_WORKFLOW=$CAN_DEPLOY_WORKFLOW .
 
 cd ".."
 
 # Use the selected Compose file to build and start the services
 echo "Building and running Docker Compose with $COMPOSE_FILE and CAN_DEPLOY_WORKFLOW=$CAN_DEPLOY_WORKFLOW..."
-sudo docker compose -f "$COMPOSE_FILE" up -d
+docker compose -f "$COMPOSE_FILE" up -d
 
 
 # Echo the react app URL

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,25 @@
 # Navigate to the lib directory
 cd "$(dirname "$0")/lib" || exit
 
+# Default: Use standard docker-compose
+COMPOSE_FILE="docker-compose.yml"
+CAN_DEPLOY_WORKFLOW=false
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --launch-containers) 
+            COMPOSE_FILE="docker-compose.privilleged.yml"
+            CAN_DEPLOY_WORKFLOW=true
+            ;;
+        *) 
+            echo "Unknown parameter: $1"; 
+            exit 1 
+            ;;
+    esac
+    shift
+done
+
 # Function to handle cleanup on keyboard interrupt
 cleanup() {
     echo "Caught interrupt signal. Stopping Docker Compose services..."
@@ -13,21 +32,10 @@ cleanup() {
 # Trap the SIGINT signal (Ctrl+C) and run the cleanup function
 trap cleanup SIGINT
 
-# Build and run Docker Compose
-echo "Building and running Docker Compose in lib directory..."
-sudo docker compose up -d
-
 # Navigate to the FastAPI directory (update this path to the correct one)
 cd "./otto_backend/" || exit
 mkdir .cache
 
-LOCK_FILE="poetry.lock"
-
-if [ -f "$LOCK_FILE" ]; then
-    echo "$LOCK_FILE found. Removing..."
-    rm "$LOCK_FILE"
-    echo "$LOCK_FILE removed."
-fi
 
 echo "Building slim base image..."
 sudo docker build -f slim-base.Dockerfile -t farhan0167/otto-m8-slim-base:latest .
@@ -35,13 +43,22 @@ sudo docker build -f slim-base.Dockerfile -t farhan0167/otto-m8-slim-base:latest
 echo "Building base image..."
 sudo docker build -f base.Dockerfile -t farhan0167/otto-m8-base:latest .
 
+sudo docker build -f server.Dockerfile -t farhan0167/otto-m8-server:latest .
+
+cd "../dashboard"
+
+echo "Building dashboard image..."
+sudo docker build -f Dockerfile -t farhan0167/otto-m8-dashboard:latest --build-arg CAN_DEPLOY_WORKFLOW=$CAN_DEPLOY_WORKFLOW .
+
+cd ".."
+
+# Use the selected Compose file to build and start the services
+echo "Building and running Docker Compose with $COMPOSE_FILE and CAN_DEPLOY_WORKFLOW=$CAN_DEPLOY_WORKFLOW..."
+sudo docker compose -f "$COMPOSE_FILE" up -d
+
+
 # Echo the react app URL
 echo "Otto Dashboard URL: http://localhost:3000"
+echo "Otto Server URL: http://localhost:8000"
 
-# Install dependencies
-echo "Installing dependencies..."
-poetry install
-
-# Start the FastAPI server using Uvicorn
-echo "Starting FastAPI server..."
-poetry run uvicorn client:app --host 0.0.0.0 --port 8000 --reload
+docker logs -f otto-server


### PR DESCRIPTION
This PR aims to improve the UX for getting started with otto-m8. Previously, users would need to manually install poetry, and ensure that they have the right python versions to get started while the dashboard, database, etc were being packaged in docker containers. This PR now packages the otto-m8 backend into a docker container as well. Now since we launch workflows as containers, we will need to mount the docker socket to the container, which would allow the server container to access the docker daemon and in turn give it the ability to launch containers. Now I understand some users may not be comfortable with that idea, so there's still an option for not mounting it, which will just mean that workflows created cannot be deployed but they can still be tested. 