### PR TITLE
fix: env var doesnt show as bool

### DIFF
--- a/lib/dashboard/src/components/Pages/Lambdas/LambdasPage.js
+++ b/lib/dashboard/src/components/Pages/Lambdas/LambdasPage.js
@@ -268,7 +268,7 @@ const LambdaModal = ({
         }
       </Modal.Header>
       <Modal.Body>
-        {canDeployContainers===true ?  (<div style={{marginBottom: '30px'}}>
+        {canDeployContainers==="true" ?  (<div style={{marginBottom: '30px'}}>
               <Row>
                   <Col style={{display: 'flex', justifyContent: 'flex-start'}}>
                       <Form style={{width: '100%', marginBottom: '0px'}}>

--- a/lib/dashboard/src/components/Pages/Workflows/Workflow.js
+++ b/lib/dashboard/src/components/Pages/Workflows/Workflow.js
@@ -590,7 +590,7 @@ export default function Flow() {
                   <Stack variant="outlined" aria-label="Loading button group" direction="row" spacing={1} sx={{height: '40px'}}>
                       <Button id='add-block-button' color='primary' variant='contained' sx={{width: '120px'}} onClick={addNodeButtonClick} size='medium'>Add Block</Button>
                       <Button color='primary' variant='contained' sx={{width: '160px'}} onClick={handleShowTestWorkflow} size='medium'>Test Workflow</Button>
-                      {canDeployWorkflow===true && <Button color='primary' variant='contained' sx={{width: '120px'}} onClick={handleRunWorkflowButton} size='medium'>Deploy</Button>}
+                      {canDeployWorkflow==="true" && <Button color='primary' variant='contained' sx={{width: '120px'}} onClick={handleRunWorkflowButton} size='medium'>Deploy</Button>}
                       <Tooltip title='Save Draft'>
                         <Button onClick={handleDraftSave} variant='outlined' sx={{minWidth: '40px', width: '45px', padding: '0px'}}>
                           <TfiSave size={20} className='template-action'/>


### PR DESCRIPTION
This was causing the deploy button to never show up even if users configured launch containers. This fixes it by treating the env var as a string.