### PR TITLE
Bug Fixes

### DIFF
--- a/lib/dashboard/src/components/Pages/Workflows/Utils/CreateRunConfig.js
+++ b/lib/dashboard/src/components/Pages/Workflows/Utils/CreateRunConfig.js
@@ -12,13 +12,7 @@
 export const createRunConfigForNode = (data) => {
     // TODO: Create Run Config
     let run_config = {}
-    // TODO: This is a temporary fix for Issue #12 and addressed in PR #49, clean this up.
-    if (data.prompt){
-        data.prompt = cleanString(data.prompt)
-    }
-    if (data.system){
-        data.system = cleanString(data.system)
-    }
+
     const sidebar_fields = data.sidebar_fields
     if (!sidebar_fields) {
         return run_config
@@ -31,7 +25,15 @@ export const createRunConfigForNode = (data) => {
         if (sidebar_fields[i].type === 'multimodal_selector') {
             run_config[ sidebar_fields[i].image.name ] = data[ sidebar_fields[i].image.name ]
             run_config[ sidebar_fields[i].text.name ] = data[ sidebar_fields[i].text.name ]
-        } else{
+        } 
+        else if (
+            sidebar_fields[i].type === 'text' 
+            || sidebar_fields[i].type === 'textarea' 
+            || sidebar_fields[i].type === 'prompt_template'
+        ){
+            run_config[sidebar_fields[i].name] = cleanString(data[sidebar_fields[i].name])
+        }
+        else{
             run_config[sidebar_fields[i].name] = data[sidebar_fields[i].name]
         }
     }
@@ -42,5 +44,6 @@ const cleanString = (data) => {
     return data
     .replace(/\r?\n|\r/g, '\\n')   // Escape newlines (both \n and \r\n)
     .replace(/\t/g, '\\t')        // Escape tabs
-    .replace(/[^\x20-\x7E]/g, '');
+    .replace(/[^\x20-\x7E]/g, '')
+    .replace(/'/g, '"'); // replace any ' with " which solves Issue #12
 }

--- a/lib/dashboard/src/components/Pages/Workflows/Workflow.js
+++ b/lib/dashboard/src/components/Pages/Workflows/Workflow.js
@@ -586,15 +586,15 @@ export default function Flow() {
               </Grid>
               <Grid item xs={9}>
                 <Box sx={{ display: 'flex', marginTop: '10px', marginBottom: '20px' }}>
-                  <Stack variant="outlined" aria-label="Loading button group" direction="row" spacing={1} sx={{height: '40px'}}>
-                      <Button id='add-block-button' color='primary' variant='contained' sx={{width: '120px'}} onClick={addNodeButtonClick} size='medium'>Add Block</Button>
-                      <Button color='primary' variant='contained' sx={{width: '160px'}} onClick={handleShowTestWorkflow} size='medium'>Test Workflow</Button>
-                      {canDeployWorkflow==="true" && <Button color='primary' variant='contained' sx={{width: '120px'}} onClick={handleRunWorkflowButton} size='medium'>Deploy</Button>}
+                  <Stack variant="outlined" aria-label="Loading button group" direction="row" spacing={1.4} sx={{height: '40px'}}>
                       <Tooltip title='Save Draft'>
                         <Button onClick={handleDraftSave} variant='outlined' sx={{minWidth: '40px', width: '45px', padding: '0px'}}>
                           <TfiSave size={20} className='template-action'/>
                         </Button> 
                       </Tooltip>
+                      <Button id='add-block-button' color='primary' variant='contained' sx={{width: '120px'}} onClick={addNodeButtonClick} size='medium'>Add Block</Button>
+                      <Button color='primary' variant='contained' sx={{width: '160px'}} onClick={handleShowTestWorkflow} size='medium'>Test Workflow</Button>
+                      {canDeployWorkflow==="true" && <Button color='primary' variant='contained' sx={{width: '120px'}} onClick={handleRunWorkflowButton} size='medium'>Deploy</Button>}
                   </Stack>
 
                   <TestWorkflow 

--- a/lib/otto_backend/core/container_utils/docker_tools.py
+++ b/lib/otto_backend/core/container_utils/docker_tools.py
@@ -93,9 +93,10 @@ class DockerTools:
         Given a range of ports, find the first available one. This function
         is used to find an available port for the container to bind to.
         """
+        host_ip = "host.docker.internal"
         for port in range(start_port, end_port + 1):
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                result = s.connect_ex(('localhost', port))
+                result = s.connect_ex((host_ip, port))
                 if result != 0:
                     return port
         raise RuntimeError("No available ports in the specified range")


### PR DESCRIPTION
- Fix bugs related to launching docker containers that arise because of lack of string escaping for certain characters. Specifically if strings aren't cleaned accordingly, when saving the backend template to a container, it would break the json file if characters such as new lines aren't escaped properly. Similarly, there was an error for the longest time addressed first in #12 where a user input that includes a single quote was breaking the code to launch docker containers. That was specifically because of this line: `RUN echo '{json_payload}' > /app/data.json`. Any single quote in the json payload would trip that specific line. Therefore we fix it by simply replacing any single quotes with double quotes. Although not ideal but it will serve our purpose for now.
- The other bug that is addressed in the PR is related to finding an available port within the host to launch a workflow container. Since moving the server to a docker container, the code to find an available port wasnt changed, which caused the code to look for an available port within the docker container which will always return a 8001. An if there's another workflow deployed on the host machine on 8001, the faulty return would throw a port conflict.