### PR TITLE
Add memory to llm

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Below is an example of a workflow that incorporates Langchain's PDF Parser to bu
 
 - Install the library:
 ```
-pip install otto-m8
+pip install -U otto-m8
 ```
 
 - And then run:

--- a/README.md
+++ b/README.md
@@ -241,7 +241,9 @@ Huggingface's pipeline abstraction. Below is a simple demo of the `Salesforce/bl
 - [x] Multimodality for OpenAI (Experimental)
 - [x] SDK for interacting with deployed workflows
 - [x] Observability for every block's output like a Logger
-- [ ] Memory for Chatbot and RAG. Goal is to not clutter the drawing board.
+- Memory for Chatbot and RAG. Goal is to not clutter the drawing board.
+  - [x] Memory
+  - [ ] RAG
 - [x] Streamline workflow creation, edits and redeployment. Some form of version control
 - [x] Apart from Lambdas that deploy seperate docker containers for custom code, build a custom code block which is deployed within the workflow container.
 - [ ] Creating other Block types: Conditionals, Aggregators, Loops. This will require change to how workflow runs and introducing handle types in the dashboard.

--- a/lib/dashboard/src/components/Pages/Home/examples.json
+++ b/lib/dashboard/src/components/Pages/Home/examples.json
@@ -124,60 +124,80 @@
                 "data": {
                   "label": "220c4692-eb4d-4ab8-9ce8-c1e9d89673b2",
                   "sidebar_fields": [
-                    {
-                      "name": "custom_name",
-                      "display_name": "Block Name",
-                      "default_value": "",
-                      "type": "text",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": true
-                    },
-                    {
-                      "name": "model",
-                      "display_name": "Model",
-                      "default_value": "gpt-4o-mini",
-                      "type": "text",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": true
-                    },
-                    {
-                      "name": "openai_api_key",
-                      "display_name": "API Key",
-                      "default_value": "",
-                      "type": "password",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": false
-                    },
-                    {
-                      "name": "system",
-                      "display_name": "System Message",
-                      "default_value": "",
-                      "type": "textarea",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": false
-                    },
-                    {
-                      "name": "prompt_template",
-                      "display_name": "Prompt Template",
-                      "default_value": "",
-                      "type": "prompt_template",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": false
-                    },
-                    {
-                      "name": "tools",
-                      "display_name": "Tools",
-                      "default_value": [],
-                      "type": "tool_list",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": false
-                    }
+          {
+            "name": "custom_name",
+            "display_name": "Block Name",
+            "default_value": "",
+            "type": "text",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": true
+          },
+          {
+            "name": "model",
+            "display_name": "Model",
+            "default_value": "gpt-4o-mini",
+            "type": "text",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": true
+          },
+          {
+            "name": "openai_api_key",
+            "display_name": "API Key",
+            "default_value": "",
+            "type": "password",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": false
+          },
+          {
+            "name": "chat_memory",
+            "display_name": "Memory",
+            "default_value": "",
+            "type": "static_dropdown",
+            "metadata": {
+              "dropdown_options": [
+                {
+                  "value": "",
+                  "label": "No Memory"
+                },
+                {
+                  "value": "basic_memory",
+                  "label": "Basic Memory"
+                }
+              ]
+            },
+            "is_run_config": true,
+            "show_in_ui": false
+          },
+          {
+            "name": "system",
+            "display_name": "System Message",
+            "default_value": "",
+            "type": "textarea",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": false
+          },
+          {
+            "name": "prompt_template",
+            "display_name": "Prompt Template",
+            "default_value": "",
+            "type": "prompt_template",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": false
+          },
+          {
+            "name": "tools",
+            "display_name": "Tools",
+            "default_value": [],
+            "type": "tool_list",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": false
+          }
                   ],
                   "block_ui_fields": [
                     {
@@ -185,7 +205,7 @@
                       "display_name": "Block Name",
                       "default_value": "",
                       "type": "text",
-                      "dropdown_options": [],
+                      "metadata": {},
                       "is_run_config": true,
                       "show_in_ui": true
                     },
@@ -194,13 +214,13 @@
                       "display_name": "Model",
                       "default_value": "gpt-4o-mini",
                       "type": "text",
-                      "dropdown_options": [],
+                      "metadata": {},
                       "is_run_config": true,
                       "show_in_ui": true
                     }
                   ],
                   "custom_name": "",
-                  "source_code": "import requests\nimport json\n\nfrom openai import OpenAI\n\n\nfrom implementations.base import (\n    BaseImplementation,\n    BlockMetadata,\n    Field,\n    FieldType\n)\nfrom extensions.llm_tools.openai_tool import OpenAITool\nfrom core.input_parser.prompt_template import PromptTemplate\n\n\nclass OpenAIChat(BaseImplementation):\n    \"\"\"Task definition of the OpenAI Chat Completion.\"\"\"\n    display_name = 'OpenAI Chat Completion'\n    block_type = 'process'\n    block_metadata = BlockMetadata([\n        Field(name=\"model\", display_name=\"Model\", is_run_config=True, default_value='gpt-4o-mini'),\n        Field(name=\"openai_api_key\", display_name=\"API Key\", is_run_config=True, show_in_ui=False, type=FieldType.PASSWORD.value),\n        Field(name=\"system\", display_name=\"System Message\", is_run_config=True, show_in_ui=False, type=FieldType.TEXTAREA.value),\n        Field(name=\"prompt_template\", display_name=\"Prompt Template\", is_run_config=True, show_in_ui=False, type=FieldType.PROMPT_TEMPLATE.value),\n        Field(name=\"tools\", display_name=\"Tools\", is_run_config=True, default_value=[], show_in_ui=False, type=FieldType.TOOL_LIST.value),\n    ])\n    \n    def __init__(self, run_config:dict) -> None:\n        super().__init__()\n        self.run_config = run_config\n        if not self.run_config.get('openai_api_key'):\n            raise Exception(\"OpenAI API key is not specified in the run config\")\n        self.openAI_client = OpenAI(\n            api_key=self.run_config.get('openai_api_key'),\n        ) \n        self.messages = []\n        self.available_tools = {}\n        self.model = 'gpt-4o-mini'\n        self.tools = None\n        self.prompt_template = None\n        self.create_payload_from_run_config()\n    \n    def run(self, input_:dict) -> dict:\n        messages = []\n        messages.append(self.insert_system_message())\n        \n        # Create prompt\n        parse_input = PromptTemplate(\n            input_=input_, \n            template=self.prompt_template\n        )\n        prompt_template = parse_input()\n        \n        # Flag to determine if a function is available to be called\n        make_function_call = False\n        messages.append({\"role\": \"user\", \"content\": prompt_template})\n\n        # Make the first call.\n        response = self.openAI_client.chat.completions.create(\n            model=self.model,\n            messages=messages,\n            tools=self.tools\n        )\n        response = response.dict()\n        choice = response['choices'][0]\n        messages.append(\n            self.openai_response_get_message(\n                response_choice=choice\n            )\n        )\n        response['conversation'] = messages[1:]\n        # If model chose not to call any tools, return the response\n        if not choice['message'].get('tool_calls'):\n            return json.loads(json.dumps(response))\n        \n        # If model chose to call tools, then call the available tools.\n        if choice['message'].get('tool_calls'):\n            for tool_call in choice['message']['tool_calls']:\n                tool_name = tool_call['function']['name']\n                function_to_call = self.available_tools.get(tool_name)\n                if function_to_call is None:\n                    continue\n                make_function_call = True\n                function_params = json.loads(tool_call['function']['arguments'])\n                function_response = function_to_call.run(\n                    # TODO: By json.loads here, we are assuming that the input is json. Can we enforce that via some data structure?\n                    {'data' : json.dumps(function_params)}\n                )\n                messages.append({\n                    \"role\": \"tool\",\n                    \"content\": str(function_response),\n                    \"tool_call_id\": tool_call['id']\n                })\n        # If no functions were available for the tools, simply return the response\n        if not make_function_call:\n            return json.loads(json.dumps(response))\n        # Else, utilize the function response to query the OpenAI API.\n        response = self.openAI_client.chat.completions.create(\n            model=self.model,\n            messages=messages,\n            tools=self.tools\n        )\n        response = response.dict()\n        choice = response['choices'][0]\n        messages.append(\n            self.openai_response_get_message(\n                response_choice=choice\n            )\n        )\n\n        response['conversation'] = messages[1:]\n        return json.loads(json.dumps(response))\n    \n    def openai_response_get_message(self, response_choice):\n        \"\"\"\n        Process the response from OpenAI's chat.completions.create API call, \n        returning the message that should be appended to the conversation.\n\n        Args:\n            response_choice: The response from OpenAI's chat.completions.create API call\n        \n        Returns:\n            A dictionary containing the message to be appended to the conversation\n        \"\"\"\n        message = {\"role\": \"\"}\n        #response_choice = response.choices[0]\n        message['role'] = response_choice[\"message\"][\"role\"]\n        if response_choice[\"message\"]['content']:\n            message['content'] = response_choice[\"message\"][\"content\"]\n        if response_choice[\"message\"]['tool_calls']:\n            message['tool_calls'] = response_choice[\"message\"][\"tool_calls\"]\n        return message\n        \n        \n    \n    def create_payload_from_run_config(self) -> dict:\n\n        model = self.run_config.get('model', 'gpt-4o-mini')\n        self.model = model\n        \n        prompt_template = self.run_config.get('prompt_template')\n        self.prompt_template = prompt_template\n            \n        # Process any tools available\n        tools = self.run_config.get('tools')\n        if tools:\n            self.tools = []\n            for tool in tools:\n                openai_tool = OpenAITool()\n                tool_schema = openai_tool.process_tool(tool)\n                self.tools.append(tool_schema)\n                self.available_tools[ tool['name'] ] = openai_tool.implements\n    \n    def insert_system_message(self):\n        system_message = self.run_config.get('system')\n        return {\"role\": \"system\", \"content\": system_message}\n        \n        ",
+                  "source_code": "import requests\nimport json\n\nfrom openai import OpenAI\n\n\nfrom implementations.base import (\n    BaseImplementation,\n    BlockMetadata,\n    Field,\n    FieldType,\n    StaticDropdownOption\n)\nfrom extensions.llm_tools.openai_tool import OpenAITool\nfrom extensions.llm_memory.types import LLMChatMemoryType\nfrom extensions.llm_memory.chat_memory import ChatMemory\nfrom extensions.llm_memory.base import BaseMemory\nfrom core.input_parser.prompt_template import PromptTemplate\n\n\nclass OpenAIChat(BaseImplementation):\n    \"\"\"Task definition of the OpenAI Chat Completion.\"\"\"\n    display_name = 'OpenAI Chat Completion'\n    block_type = 'process'\n    block_metadata = BlockMetadata([\n        Field(\n            name=\"model\", \n            display_name=\"Model\", \n            is_run_config=True, \n            default_value='gpt-4o-mini'\n        ),\n        Field(\n            name=\"openai_api_key\", \n            display_name=\"API Key\", \n            is_run_config=True, \n            show_in_ui=False, \n            type=FieldType.PASSWORD.value\n        ),\n        Field(\n            name=\"chat_memory\",\n            display_name=\"Memory\",\n            is_run_config=True,\n            show_in_ui=False,\n            default_value='',\n            type=FieldType.STATIC_DROPDOWN.value,\n            metadata={\n                \"dropdown_options\": [\n                    StaticDropdownOption(\n                        label=\"No Memory\", value=''\n                    ).__dict__,\n                    StaticDropdownOption(\n                        label=\"Basic Memory\", value=LLMChatMemoryType.BASIC_MEMORY.value\n                    ).__dict__\n                ]\n            }\n        ),\n        Field(\n            name=\"system\", \n            display_name=\"System Message\", \n            is_run_config=True, \n            show_in_ui=False, \n            type=FieldType.TEXTAREA.value\n        ),\n        Field(\n            name=\"prompt_template\", \n            display_name=\"Prompt Template\", \n            is_run_config=True, \n            show_in_ui=False, \n            type=FieldType.PROMPT_TEMPLATE.value\n        ),\n        Field(\n            name=\"tools\", \n            display_name=\"Tools\", \n            is_run_config=True, \n            default_value=[], \n            show_in_ui=False, \n            type=FieldType.TOOL_LIST.value\n        ),\n    ])\n    \n    def __init__(self, run_config:dict) -> None:\n        super().__init__()\n        self.run_config = run_config\n        if not self.run_config.get('openai_api_key'):\n            raise Exception(\"OpenAI API key is not specified in the run config\")\n        self.openAI_client = OpenAI(\n            api_key=self.run_config.get('openai_api_key'),\n        )\n        self.chat_memory:BaseMemory = ChatMemory().initialize(\n            memory_type=run_config.get('chat_memory'),\n            block_uuid=run_config['block_uuid']\n        )\n        self.messages = []\n        self.available_tools = {}\n        self.model = 'gpt-4o-mini'\n        self.tools = None\n        self.prompt_template = None\n        self.create_payload_from_run_config()\n    \n    def run(self, input_:dict) -> dict:\n        messages = []\n        \n        # Create prompt\n        parse_input = PromptTemplate(\n            input_=input_, \n            template=self.prompt_template\n        )\n        prompt_template = parse_input()\n        \n        # Flag to determine if a function is available to be called\n        make_function_call = False\n        messages = self.chat_memory.get(\n            user_prompt={\n                'role': 'user',\n                'content': prompt_template\n            }\n        )\n        messages = [self.insert_system_message()] + messages\n\n        # Make the first call.\n        response = self.openAI_client.chat.completions.create(\n            model=self.model,\n            messages=messages,\n            tools=self.tools\n        )\n        response = response.dict()\n        choice = response['choices'][0]\n        messages.append(\n            self.openai_response_get_message(\n                response_choice=choice\n            )\n        )\n        self.chat_memory.put(messages)\n        \n        response['conversation'] = messages[1:]\n        # If model chose not to call any tools, return the response\n        if not choice['message'].get('tool_calls'):\n            return json.loads(json.dumps(response))\n        \n        # If model chose to call tools, then call the available tools.\n        if choice['message'].get('tool_calls'):\n            for tool_call in choice['message']['tool_calls']:\n                tool_name = tool_call['function']['name']\n                function_to_call = self.available_tools.get(tool_name)\n                if function_to_call is None:\n                    continue\n                make_function_call = True\n                function_params = json.loads(tool_call['function']['arguments'])\n                function_response = function_to_call.run(\n                    # TODO: By json.loads here, we are assuming that the input is json. Can we enforce that via some data structure?\n                    {'data' : json.dumps(function_params)}\n                )\n                messages.append({\n                    \"role\": \"tool\",\n                    \"content\": str(function_response),\n                    \"tool_call_id\": tool_call['id']\n                })\n                self.chat_memory.put(messages)\n        # If no functions were available for the tools, simply return the response\n        if not make_function_call:\n            return json.loads(json.dumps(response))\n        # Else, utilize the function response to query the OpenAI API.\n        response = self.openAI_client.chat.completions.create(\n            model=self.model,\n            messages=messages,\n            tools=self.tools\n        )\n        response = response.dict()\n        choice = response['choices'][0]\n        messages.append(\n            self.openai_response_get_message(\n                response_choice=choice\n            )\n        )\n        self.chat_memory.put(messages)\n\n        response['conversation'] = messages[1:]\n        return json.loads(json.dumps(response))\n    \n    def openai_response_get_message(self, response_choice):\n        \"\"\"\n        Process the response from OpenAI's chat.completions.create API call, \n        returning the message that should be appended to the conversation.\n\n        Args:\n            response_choice: The response from OpenAI's chat.completions.create API call\n        \n        Returns:\n            A dictionary containing the message to be appended to the conversation\n        \"\"\"\n        message = {\"role\": \"\"}\n        #response_choice = response.choices[0]\n        message['role'] = response_choice[\"message\"][\"role\"]\n        if response_choice[\"message\"]['content']:\n            message['content'] = response_choice[\"message\"][\"content\"]\n        if response_choice[\"message\"]['tool_calls']:\n            message['tool_calls'] = response_choice[\"message\"][\"tool_calls\"]\n        return message\n        \n        \n    \n    def create_payload_from_run_config(self) -> dict:\n\n        model = self.run_config.get('model', 'gpt-4o-mini')\n        self.model = model\n        \n        prompt_template = self.run_config.get('prompt_template')\n        self.prompt_template = prompt_template\n            \n        # Process any tools available\n        tools = self.run_config.get('tools')\n        if tools:\n            self.tools = []\n            for tool in tools:\n                openai_tool = OpenAITool()\n                tool_schema = openai_tool.process_tool(tool)\n                self.tools.append(tool_schema)\n                self.available_tools[ tool['name'] ] = openai_tool.implements\n    \n    def insert_system_message(self):\n        system_message = self.run_config.get('system')\n        return {\"role\": \"system\", \"content\": system_message}\n        \n        ",
                   "source_path": "implementations/tasks/openai/openai_chat.py",
                   "source_hash": "eaa7e645b75b13086d63f9b258476ae7f4bf8ea1",
                   "process_type": "task",
@@ -378,60 +398,80 @@
                 "data": {
                   "label": "220c4692-eb4d-4ab8-9ce8-c1e9d89673b2",
                   "sidebar_fields": [
-                    {
-                      "name": "custom_name",
-                      "display_name": "Block Name",
-                      "default_value": "",
-                      "type": "text",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": true
-                    },
-                    {
-                      "name": "model",
-                      "display_name": "Model",
-                      "default_value": "gpt-4o-mini",
-                      "type": "text",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": true
-                    },
-                    {
-                      "name": "openai_api_key",
-                      "display_name": "API Key",
-                      "default_value": "",
-                      "type": "password",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": false
-                    },
-                    {
-                      "name": "system",
-                      "display_name": "System Message",
-                      "default_value": "",
-                      "type": "textarea",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": false
-                    },
-                    {
-                      "name": "prompt_template",
-                      "display_name": "Prompt Template",
-                      "default_value": "",
-                      "type": "prompt_template",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": false
-                    },
-                    {
-                      "name": "tools",
-                      "display_name": "Tools",
-                      "default_value": [],
-                      "type": "tool_list",
-                      "dropdown_options": [],
-                      "is_run_config": true,
-                      "show_in_ui": false
-                    }
+          {
+            "name": "custom_name",
+            "display_name": "Block Name",
+            "default_value": "",
+            "type": "text",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": true
+          },
+          {
+            "name": "model",
+            "display_name": "Model",
+            "default_value": "gpt-4o-mini",
+            "type": "text",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": true
+          },
+          {
+            "name": "openai_api_key",
+            "display_name": "API Key",
+            "default_value": "",
+            "type": "password",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": false
+          },
+          {
+            "name": "chat_memory",
+            "display_name": "Memory",
+            "default_value": "",
+            "type": "static_dropdown",
+            "metadata": {
+              "dropdown_options": [
+                {
+                  "value": "",
+                  "label": "No Memory"
+                },
+                {
+                  "value": "basic_memory",
+                  "label": "Basic Memory"
+                }
+              ]
+            },
+            "is_run_config": true,
+            "show_in_ui": false
+          },
+          {
+            "name": "system",
+            "display_name": "System Message",
+            "default_value": "",
+            "type": "textarea",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": false
+          },
+          {
+            "name": "prompt_template",
+            "display_name": "Prompt Template",
+            "default_value": "",
+            "type": "prompt_template",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": false
+          },
+          {
+            "name": "tools",
+            "display_name": "Tools",
+            "default_value": [],
+            "type": "tool_list",
+            "metadata": {},
+            "is_run_config": true,
+            "show_in_ui": false
+          }
                   ],
                   "block_ui_fields": [
                     {
@@ -439,7 +479,7 @@
                       "display_name": "Block Name",
                       "default_value": "",
                       "type": "text",
-                      "dropdown_options": [],
+                      "metadata": {},
                       "is_run_config": true,
                       "show_in_ui": true
                     },
@@ -448,13 +488,13 @@
                       "display_name": "Model",
                       "default_value": "gpt-4o-mini",
                       "type": "text",
-                      "dropdown_options": [],
+                      "metadata": {},
                       "is_run_config": true,
                       "show_in_ui": true
                     }
                   ],
                   "custom_name": "",
-                  "source_code": "import requests\nimport json\n\nfrom openai import OpenAI\n\n\nfrom implementations.base import (\n    BaseImplementation,\n    BlockMetadata,\n    Field,\n    FieldType\n)\nfrom extensions.llm_tools.openai_tool import OpenAITool\nfrom core.input_parser.prompt_template import PromptTemplate\n\n\nclass OpenAIChat(BaseImplementation):\n    \"\"\"Task definition of the OpenAI Chat Completion.\"\"\"\n    display_name = 'OpenAI Chat Completion'\n    block_type = 'process'\n    block_metadata = BlockMetadata([\n        Field(name=\"model\", display_name=\"Model\", is_run_config=True, default_value='gpt-4o-mini'),\n        Field(name=\"openai_api_key\", display_name=\"API Key\", is_run_config=True, show_in_ui=False, type=FieldType.PASSWORD.value),\n        Field(name=\"system\", display_name=\"System Message\", is_run_config=True, show_in_ui=False, type=FieldType.TEXTAREA.value),\n        Field(name=\"prompt_template\", display_name=\"Prompt Template\", is_run_config=True, show_in_ui=False, type=FieldType.PROMPT_TEMPLATE.value),\n        Field(name=\"tools\", display_name=\"Tools\", is_run_config=True, default_value=[], show_in_ui=False, type=FieldType.TOOL_LIST.value),\n    ])\n    \n    def __init__(self, run_config:dict) -> None:\n        super().__init__()\n        self.run_config = run_config\n        if not self.run_config.get('openai_api_key'):\n            raise Exception(\"OpenAI API key is not specified in the run config\")\n        self.openAI_client = OpenAI(\n            api_key=self.run_config.get('openai_api_key'),\n        ) \n        self.messages = []\n        self.available_tools = {}\n        self.model = 'gpt-4o-mini'\n        self.tools = None\n        self.prompt_template = None\n        self.create_payload_from_run_config()\n    \n    def run(self, input_:dict) -> dict:\n        messages = []\n        messages.append(self.insert_system_message())\n        \n        # Create prompt\n        parse_input = PromptTemplate(\n            input_=input_, \n            template=self.prompt_template\n        )\n        prompt_template = parse_input()\n        \n        # Flag to determine if a function is available to be called\n        make_function_call = False\n        messages.append({\"role\": \"user\", \"content\": prompt_template})\n\n        # Make the first call.\n        response = self.openAI_client.chat.completions.create(\n            model=self.model,\n            messages=messages,\n            tools=self.tools\n        )\n        response = response.dict()\n        choice = response['choices'][0]\n        messages.append(\n            self.openai_response_get_message(\n                response_choice=choice\n            )\n        )\n        response['conversation'] = messages[1:]\n        # If model chose not to call any tools, return the response\n        if not choice['message'].get('tool_calls'):\n            return json.loads(json.dumps(response))\n        \n        # If model chose to call tools, then call the available tools.\n        if choice['message'].get('tool_calls'):\n            for tool_call in choice['message']['tool_calls']:\n                tool_name = tool_call['function']['name']\n                function_to_call = self.available_tools.get(tool_name)\n                if function_to_call is None:\n                    continue\n                make_function_call = True\n                function_params = json.loads(tool_call['function']['arguments'])\n                function_response = function_to_call.run(\n                    # TODO: By json.loads here, we are assuming that the input is json. Can we enforce that via some data structure?\n                    {'data' : json.dumps(function_params)}\n                )\n                messages.append({\n                    \"role\": \"tool\",\n                    \"content\": str(function_response),\n                    \"tool_call_id\": tool_call['id']\n                })\n        # If no functions were available for the tools, simply return the response\n        if not make_function_call:\n            return json.loads(json.dumps(response))\n        # Else, utilize the function response to query the OpenAI API.\n        response = self.openAI_client.chat.completions.create(\n            model=self.model,\n            messages=messages,\n            tools=self.tools\n        )\n        response = response.dict()\n        choice = response['choices'][0]\n        messages.append(\n            self.openai_response_get_message(\n                response_choice=choice\n            )\n        )\n\n        response['conversation'] = messages[1:]\n        return json.loads(json.dumps(response))\n    \n    def openai_response_get_message(self, response_choice):\n        \"\"\"\n        Process the response from OpenAI's chat.completions.create API call, \n        returning the message that should be appended to the conversation.\n\n        Args:\n            response_choice: The response from OpenAI's chat.completions.create API call\n        \n        Returns:\n            A dictionary containing the message to be appended to the conversation\n        \"\"\"\n        message = {\"role\": \"\"}\n        #response_choice = response.choices[0]\n        message['role'] = response_choice[\"message\"][\"role\"]\n        if response_choice[\"message\"]['content']:\n            message['content'] = response_choice[\"message\"][\"content\"]\n        if response_choice[\"message\"]['tool_calls']:\n            message['tool_calls'] = response_choice[\"message\"][\"tool_calls\"]\n        return message\n        \n        \n    \n    def create_payload_from_run_config(self) -> dict:\n\n        model = self.run_config.get('model', 'gpt-4o-mini')\n        self.model = model\n        \n        prompt_template = self.run_config.get('prompt_template')\n        self.prompt_template = prompt_template\n            \n        # Process any tools available\n        tools = self.run_config.get('tools')\n        if tools:\n            self.tools = []\n            for tool in tools:\n                openai_tool = OpenAITool()\n                tool_schema = openai_tool.process_tool(tool)\n                self.tools.append(tool_schema)\n                self.available_tools[ tool['name'] ] = openai_tool.implements\n    \n    def insert_system_message(self):\n        system_message = self.run_config.get('system')\n        return {\"role\": \"system\", \"content\": system_message}\n        \n        ",
+                  "source_code": "import requests\nimport json\n\nfrom openai import OpenAI\n\n\nfrom implementations.base import (\n    BaseImplementation,\n    BlockMetadata,\n    Field,\n    FieldType,\n    StaticDropdownOption\n)\nfrom extensions.llm_tools.openai_tool import OpenAITool\nfrom extensions.llm_memory.types import LLMChatMemoryType\nfrom extensions.llm_memory.chat_memory import ChatMemory\nfrom extensions.llm_memory.base import BaseMemory\nfrom core.input_parser.prompt_template import PromptTemplate\n\n\nclass OpenAIChat(BaseImplementation):\n    \"\"\"Task definition of the OpenAI Chat Completion.\"\"\"\n    display_name = 'OpenAI Chat Completion'\n    block_type = 'process'\n    block_metadata = BlockMetadata([\n        Field(\n            name=\"model\", \n            display_name=\"Model\", \n            is_run_config=True, \n            default_value='gpt-4o-mini'\n        ),\n        Field(\n            name=\"openai_api_key\", \n            display_name=\"API Key\", \n            is_run_config=True, \n            show_in_ui=False, \n            type=FieldType.PASSWORD.value\n        ),\n        Field(\n            name=\"chat_memory\",\n            display_name=\"Memory\",\n            is_run_config=True,\n            show_in_ui=False,\n            default_value='',\n            type=FieldType.STATIC_DROPDOWN.value,\n            metadata={\n                \"dropdown_options\": [\n                    StaticDropdownOption(\n                        label=\"No Memory\", value=''\n                    ).__dict__,\n                    StaticDropdownOption(\n                        label=\"Basic Memory\", value=LLMChatMemoryType.BASIC_MEMORY.value\n                    ).__dict__\n                ]\n            }\n        ),\n        Field(\n            name=\"system\", \n            display_name=\"System Message\", \n            is_run_config=True, \n            show_in_ui=False, \n            type=FieldType.TEXTAREA.value\n        ),\n        Field(\n            name=\"prompt_template\", \n            display_name=\"Prompt Template\", \n            is_run_config=True, \n            show_in_ui=False, \n            type=FieldType.PROMPT_TEMPLATE.value\n        ),\n        Field(\n            name=\"tools\", \n            display_name=\"Tools\", \n            is_run_config=True, \n            default_value=[], \n            show_in_ui=False, \n            type=FieldType.TOOL_LIST.value\n        ),\n    ])\n    \n    def __init__(self, run_config:dict) -> None:\n        super().__init__()\n        self.run_config = run_config\n        if not self.run_config.get('openai_api_key'):\n            raise Exception(\"OpenAI API key is not specified in the run config\")\n        self.openAI_client = OpenAI(\n            api_key=self.run_config.get('openai_api_key'),\n        )\n        self.chat_memory:BaseMemory = ChatMemory().initialize(\n            memory_type=run_config.get('chat_memory'),\n            block_uuid=run_config['block_uuid']\n        )\n        self.messages = []\n        self.available_tools = {}\n        self.model = 'gpt-4o-mini'\n        self.tools = None\n        self.prompt_template = None\n        self.create_payload_from_run_config()\n    \n    def run(self, input_:dict) -> dict:\n        messages = []\n        \n        # Create prompt\n        parse_input = PromptTemplate(\n            input_=input_, \n            template=self.prompt_template\n        )\n        prompt_template = parse_input()\n        \n        # Flag to determine if a function is available to be called\n        make_function_call = False\n        messages = self.chat_memory.get(\n            user_prompt={\n                'role': 'user',\n                'content': prompt_template\n            }\n        )\n        messages = [self.insert_system_message()] + messages\n\n        # Make the first call.\n        response = self.openAI_client.chat.completions.create(\n            model=self.model,\n            messages=messages,\n            tools=self.tools\n        )\n        response = response.dict()\n        choice = response['choices'][0]\n        messages.append(\n            self.openai_response_get_message(\n                response_choice=choice\n            )\n        )\n        self.chat_memory.put(messages)\n        \n        response['conversation'] = messages[1:]\n        # If model chose not to call any tools, return the response\n        if not choice['message'].get('tool_calls'):\n            return json.loads(json.dumps(response))\n        \n        # If model chose to call tools, then call the available tools.\n        if choice['message'].get('tool_calls'):\n            for tool_call in choice['message']['tool_calls']:\n                tool_name = tool_call['function']['name']\n                function_to_call = self.available_tools.get(tool_name)\n                if function_to_call is None:\n                    continue\n                make_function_call = True\n                function_params = json.loads(tool_call['function']['arguments'])\n                function_response = function_to_call.run(\n                    # TODO: By json.loads here, we are assuming that the input is json. Can we enforce that via some data structure?\n                    {'data' : json.dumps(function_params)}\n                )\n                messages.append({\n                    \"role\": \"tool\",\n                    \"content\": str(function_response),\n                    \"tool_call_id\": tool_call['id']\n                })\n                self.chat_memory.put(messages)\n        # If no functions were available for the tools, simply return the response\n        if not make_function_call:\n            return json.loads(json.dumps(response))\n        # Else, utilize the function response to query the OpenAI API.\n        response = self.openAI_client.chat.completions.create(\n            model=self.model,\n            messages=messages,\n            tools=self.tools\n        )\n        response = response.dict()\n        choice = response['choices'][0]\n        messages.append(\n            self.openai_response_get_message(\n                response_choice=choice\n            )\n        )\n        self.chat_memory.put(messages)\n\n        response['conversation'] = messages[1:]\n        return json.loads(json.dumps(response))\n    \n    def openai_response_get_message(self, response_choice):\n        \"\"\"\n        Process the response from OpenAI's chat.completions.create API call, \n        returning the message that should be appended to the conversation.\n\n        Args:\n            response_choice: The response from OpenAI's chat.completions.create API call\n        \n        Returns:\n            A dictionary containing the message to be appended to the conversation\n        \"\"\"\n        message = {\"role\": \"\"}\n        #response_choice = response.choices[0]\n        message['role'] = response_choice[\"message\"][\"role\"]\n        if response_choice[\"message\"]['content']:\n            message['content'] = response_choice[\"message\"][\"content\"]\n        if response_choice[\"message\"]['tool_calls']:\n            message['tool_calls'] = response_choice[\"message\"][\"tool_calls\"]\n        return message\n        \n        \n    \n    def create_payload_from_run_config(self) -> dict:\n\n        model = self.run_config.get('model', 'gpt-4o-mini')\n        self.model = model\n        \n        prompt_template = self.run_config.get('prompt_template')\n        self.prompt_template = prompt_template\n            \n        # Process any tools available\n        tools = self.run_config.get('tools')\n        if tools:\n            self.tools = []\n            for tool in tools:\n                openai_tool = OpenAITool()\n                tool_schema = openai_tool.process_tool(tool)\n                self.tools.append(tool_schema)\n                self.available_tools[ tool['name'] ] = openai_tool.implements\n    \n    def insert_system_message(self):\n        system_message = self.run_config.get('system')\n        return {\"role\": \"system\", \"content\": system_message}\n        \n        ",
                   "source_path": "implementations/tasks/openai/openai_chat.py",
                   "source_hash": "eaa7e645b75b13086d63f9b258476ae7f4bf8ea1",
                   "process_type": "task",

--- a/lib/dashboard/src/components/Pages/Workflows/Utils/CreateRunConfig.js
+++ b/lib/dashboard/src/components/Pages/Workflows/Utils/CreateRunConfig.js
@@ -21,6 +21,7 @@ export const createRunConfigForNode = (data) => {
     // sidebar_fields.forEach(field => {
     //     run_config[field.name] = data[field.name]
     // })
+    run_config [ 'block_uuid' ] = data.label
     for (let i=0; i<sidebar_fields.length; i++){
         if (sidebar_fields[i].type === 'multimodal_selector') {
             run_config[ sidebar_fields[i].image.name ] = data[ sidebar_fields[i].image.name ]

--- a/lib/otto_backend/core/connections.py
+++ b/lib/otto_backend/core/connections.py
@@ -1,0 +1,5 @@
+from redis import Redis
+
+
+# Redis connection
+redis_client = Redis(host="redis", port=6379, decode_responses=True)

--- a/lib/otto_backend/core/utils/__init__.py
+++ b/lib/otto_backend/core/utils/__init__.py
@@ -68,7 +68,7 @@ def create_run_config_for_node(data):
     
     if not sidebar_fields:
         return run_config
-    
+    run_config['block_uuid'] = data.get('label')
     for field in sidebar_fields:
         if field['type'] == 'multimodal_selector':
             run_config[field['image']['name']] = data.get(field['image']['name'])

--- a/lib/otto_backend/db/auth.py
+++ b/lib/otto_backend/db/auth.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from .db_engine import get_session
 from .models.users import Users
-from routers.dependency import token_store
+from routers.dependency import redis_client
 
 # Password hashing configuration
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -29,14 +29,14 @@ def create_token(email: str) -> str:
     redis_key = f"tokens:{token}"
     
     # Store the token data as a hash
-    token_store.hset(
+    redis_client.hset(
         name=redis_key, 
         mapping={"email": email, "expires": expires}
     )
     
     # Set expiration for the token key
     expire_after = token_expiration_unit * token_expiration_hours
-    token_store.expire(redis_key, expire_after)  # Expires in 1 hour
+    redis_client.expire(redis_key, expire_after)  # Expires in 1 hour
     
     return token
 

--- a/lib/otto_backend/db/auth.py
+++ b/lib/otto_backend/db/auth.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from .db_engine import get_session
 from .models.users import Users
-from routers.dependency import redis_client
+from core.connections import redis_client
 
 # Password hashing configuration
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")

--- a/lib/otto_backend/extensions/llm_memory/base.py
+++ b/lib/otto_backend/extensions/llm_memory/base.py
@@ -1,0 +1,5 @@
+
+
+class BaseMemory:
+    def __init__(self, block_uuid:str) -> None:
+        pass

--- a/lib/otto_backend/extensions/llm_memory/base.py
+++ b/lib/otto_backend/extensions/llm_memory/base.py
@@ -1,5 +1,43 @@
-
+from core.connections import redis_client
 
 class BaseMemory:
+    """ 
+    Base class for chat memory. On the most basic level, a memory object
+    has get and put operations. It can get chat history and put new chat history.
+    """
     def __init__(self, block_uuid:str) -> None:
-        pass
+        self.redis_key = f"chat_memory:{block_uuid}"
+        self.redis_client = redis_client
+    
+    def put(self, messages:list):
+        """
+        Stores a list of messages in the chat memory. If a message with the role 'system'
+        is present at the beginning of the list, it will be ignored. The messages are
+        stored in the Redis database under the key associated with this memory instance.
+
+        Args:
+            messages (list): A list of message dictionaries to be stored.
+        """
+        return
+    
+    def get(self, user_prompt:dict=None):
+        """
+        Retrieves the chat history and possibly appends the user's prompt message to
+        the end of the history. If the user's prompt is None, the history will not be
+        modified.
+
+        Args:
+            user_prompt (dict): The user's prompt message to be appended to the chat history.
+
+        Returns:
+            list: The chat history with the user's prompt message possibly appended.
+        """
+        return [user_prompt]
+    
+    def delete_all(self):
+        """
+        Deletes all messages stored in the chat memory for this memory instance.
+
+        Note that this is a destructive operation and cannot be undone.
+        """
+        self.redis_client.hdel(self.redis_key, 'messages')

--- a/lib/otto_backend/extensions/llm_memory/basic_memory.py
+++ b/lib/otto_backend/extensions/llm_memory/basic_memory.py
@@ -1,0 +1,36 @@
+import json
+from .base import BaseMemory
+
+class BasicMemory(BaseMemory):
+    """
+    The Basic Memory is a simple memory that stores the chat history in a list
+    as is. This kind of memory preserves the entire chat history. However, it
+    suffers from the disadvantage that if the history gets too long, it might
+    hit the limits of the LLM's context window.
+    """
+    def __init__(self, block_uuid:str) -> None:
+        super().__init__(block_uuid)
+        
+    def put(self, messages:list):
+        if messages:
+            if messages[0]['role'] == 'system':
+                messages = messages[1:]
+            self.redis_client.hset(
+                self.redis_key,
+                mapping={
+                    'messages': json.dumps(messages)
+                }
+            )
+    
+    def get(self, user_prompt:dict=None):
+        if user_prompt['content'] in ["<otto_reset_memory>", "<reset_memory>", "<clear_memory>"]:
+            self.delete_all()
+            user_prompt['content'] = ""
+        history = []
+        history = self.redis_client.hgetall(self.redis_key)
+        history = history.get('messages', [])
+        if history:
+            history = json.loads(history)
+        return history + [user_prompt]
+        
+    

--- a/lib/otto_backend/extensions/llm_memory/chat_memory.py
+++ b/lib/otto_backend/extensions/llm_memory/chat_memory.py
@@ -1,0 +1,14 @@
+from .types import LLMChatMemoryType
+from .base import BaseMemory
+
+class ChatMemory:
+    
+    def initialize(
+        self, 
+        block_uuid: str,
+        memory_type: str = LLMChatMemoryType.BASIC_MEMORY.value,
+    ) -> BaseMemory:
+        if not memory_type:
+            pass
+        if memory_type == LLMChatMemoryType.BASIC_MEMORY.value:
+            pass

--- a/lib/otto_backend/extensions/llm_memory/chat_memory.py
+++ b/lib/otto_backend/extensions/llm_memory/chat_memory.py
@@ -1,14 +1,26 @@
 from .types import LLMChatMemoryType
 from .base import BaseMemory
+from .basic_memory import BasicMemory
 
 class ChatMemory:
+    """Factory class for chat memory implementations."""
     
     def initialize(
         self, 
         block_uuid: str,
         memory_type: str = LLMChatMemoryType.BASIC_MEMORY.value,
     ) -> BaseMemory:
+        """
+        Factory method to initialize a chat memory object.
+        
+        Args:
+            block_uuid (str): The UUID of the block.
+            memory_type (str): The type of memory to initialize. Defaults to basic_memory.
+        
+        Returns:
+            BaseMemory: The chat memory object.
+        """
         if not memory_type:
-            pass
+            return BaseMemory(block_uuid)
         if memory_type == LLMChatMemoryType.BASIC_MEMORY.value:
-            pass
+            return BasicMemory(block_uuid)

--- a/lib/otto_backend/extensions/llm_memory/types.py
+++ b/lib/otto_backend/extensions/llm_memory/types.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+class LLMChatMemoryType(Enum):
+    BASIC_MEMORY = 'basic_memory'
+    

--- a/lib/otto_backend/implementations/tasks/experimental/openai_chat_vision.py
+++ b/lib/otto_backend/implementations/tasks/experimental/openai_chat_vision.py
@@ -19,10 +19,41 @@ class OpenAIChatVision(BaseImplementation):
     display_name = 'OpenAI Vision'
     block_type = 'process'
     block_metadata = BlockMetadata([
-        Field(name="model", display_name="Model", is_run_config=True, default_value='gpt-4o-mini'),
-        Field(name="openai_api_key", display_name="API Key", is_run_config=True, show_in_ui=False, type=FieldType.PASSWORD.value),
-        Field(name="system", display_name="System Message", is_run_config=True, show_in_ui=False, type=FieldType.TEXTAREA.value),
-        Field(name="prompt_template", display_name="Prompt Template", is_run_config=True, show_in_ui=False, type=FieldType.PROMPT_TEMPLATE.value),
+        Field(
+            name="model", 
+            display_name="Model", 
+            is_run_config=True, 
+            default_value='gpt-4o-mini'
+        ),
+        Field(
+            name="openai_api_key", 
+            display_name="API Key", 
+            is_run_config=True, 
+            show_in_ui=False, 
+            type=FieldType.PASSWORD.value
+        ),
+        Field(
+            name="system", 
+            display_name="System Message", 
+            is_run_config=True, 
+            show_in_ui=False, 
+            type=FieldType.TEXTAREA.value
+        ),
+        Field(
+            name="prompt_template", 
+            display_name="Prompt Template", 
+            is_run_config=True, 
+            show_in_ui=False, 
+            type=FieldType.PROMPT_TEMPLATE.value
+        ),
+        Field(
+            name="tools", 
+            display_name="Tools", 
+            is_run_config=True, 
+            default_value=[], 
+            show_in_ui=False, 
+            type=FieldType.TOOL_LIST.value
+        ),
     ])
     
     def __init__(self, run_config:dict) -> None:

--- a/lib/otto_backend/implementations/tasks/hugging_face/hugging_face_multimodal.py
+++ b/lib/otto_backend/implementations/tasks/hugging_face/hugging_face_multimodal.py
@@ -23,7 +23,12 @@ class HuggingFaceMultimodalPipeline(BaseImplementation):
     block_type = 'process'
     block_metadata = BlockMetadata([
         Field(name="modelCard", display_name="Model Card", is_run_config=True),
-        Field(name="huggingface_task_type", display_name="Hugging Face Task Type", is_run_config=True, default_value=None),
+        Field(
+            name="huggingface_task_type", 
+            display_name="Hugging Face Task Type", 
+            is_run_config=True, 
+            default_value=None
+        ),
         MultimodalField(
             display_name="Configure Multimodal Input",
             image=Field(name="image_input", display_name="Image"),

--- a/lib/otto_backend/implementations/tasks/input_blocks/image_input/image.py
+++ b/lib/otto_backend/implementations/tasks/input_blocks/image_input/image.py
@@ -14,14 +14,16 @@ class ImageInput(BaseImplementation):
     block_type = 'input'
     block_metadata = BlockMetadata([
         Field(name="button_text", is_run_config=False, default_value="Upload Image"),
-        Field(name="input_type", display_name="Input Type", is_run_config=True, show_in_ui=False,
-              type=FieldType.STATIC_DROPDOWN.value,
-              default_value=InputType.FILE.value,
-              metadata={
-                  'dropdown_options':[
-                    StaticDropdownOption(value=InputType.FILE.value, label="File").__dict__,
-                    StaticDropdownOption(value=InputType.URL.value, label="URL").__dict__,
-              ]}
+        Field(
+            name="input_type", 
+            display_name="Input Type", is_run_config=True, show_in_ui=False,
+            type=FieldType.STATIC_DROPDOWN.value,
+            default_value=InputType.FILE.value,
+            metadata={
+                'dropdown_options':[
+                StaticDropdownOption(value=InputType.FILE.value, label="File").__dict__,
+                StaticDropdownOption(value=InputType.URL.value, label="URL").__dict__,
+            ]}
         ),
     ])
     def __init__(self, run_config:dict) -> None:

--- a/lib/otto_backend/implementations/tasks/ollama/ollama_server_chat.py
+++ b/lib/otto_backend/implementations/tasks/ollama/ollama_server_chat.py
@@ -15,11 +15,36 @@ class OllamaServerChat(BaseImplementation):
     display_name = 'Ollama Chat'
     block_type = 'process'
     block_metadata = BlockMetadata([
-        Field(name="model", display_name="Model", is_run_config=True, default_value='llama3'),
-        Field(name="endpoint", display_name="Endpoint", is_run_config=True, show_in_ui=False),
-        Field(name="system", display_name="System Message", is_run_config=True, show_in_ui=False, type=FieldType.TEXTAREA.value),
-        Field(name="prompt_template", display_name="Prompt Template", is_run_config=True, show_in_ui=False, type=FieldType.PROMPT_TEMPLATE.value),
-        Field(name="tools", display_name="Tools", is_run_config=True, default_value=[], show_in_ui=False, type=FieldType.TOOL_LIST.value),
+        Field(
+            name="model", 
+            display_name="Model", 
+            is_run_config=True, default_value='llama3'
+        ),
+        Field(
+            name="endpoint", 
+            display_name="Endpoint", 
+            is_run_config=True, show_in_ui=False
+        ),
+        Field(
+            name="system", 
+            display_name="System Message", 
+            is_run_config=True, show_in_ui=False, 
+            type=FieldType.TEXTAREA.value
+        ),
+        Field(
+            name="prompt_template", 
+            display_name="Prompt Template", 
+            is_run_config=True, show_in_ui=False, 
+            type=FieldType.PROMPT_TEMPLATE.value
+        ),
+        Field(
+            name="tools", 
+            display_name="Tools", 
+            is_run_config=True, 
+            default_value=[], 
+            show_in_ui=False, 
+            type=FieldType.TOOL_LIST.value
+        ),
     ])
     
     def __init__(self, run_config:dict) -> None:

--- a/lib/otto_backend/implementations/tasks/ollama/ollama_server_chat.py
+++ b/lib/otto_backend/implementations/tasks/ollama/ollama_server_chat.py
@@ -4,9 +4,13 @@ from implementations.base import (
     BaseImplementation,
     BlockMetadata,
     Field,
-    FieldType
+    FieldType,
+    StaticDropdownOption
 )
 from extensions.llm_tools.ollama_tool import OllamaTool
+from extensions.llm_memory.types import LLMChatMemoryType
+from extensions.llm_memory.chat_memory import ChatMemory
+from extensions.llm_memory.base import BaseMemory
 from core.input_parser.prompt_template import PromptTemplate
 
 
@@ -22,8 +26,27 @@ class OllamaServerChat(BaseImplementation):
         ),
         Field(
             name="endpoint", 
-            display_name="Endpoint", 
+            display_name="Endpoint",
+            default_value='http://localhost:11434/api/chat', 
             is_run_config=True, show_in_ui=False
+        ),
+        Field(
+            name="chat_memory",
+            display_name="Memory",
+            is_run_config=True,
+            show_in_ui=False,
+            default_value='',
+            type=FieldType.STATIC_DROPDOWN.value,
+            metadata={
+                "dropdown_options": [
+                    StaticDropdownOption(
+                        label="No Memory", value=''
+                    ).__dict__,
+                    StaticDropdownOption(
+                        label="Basic Memory", value=LLMChatMemoryType.BASIC_MEMORY.value
+                    ).__dict__
+                ]
+            }
         ),
         Field(
             name="system", 
@@ -55,12 +78,20 @@ class OllamaServerChat(BaseImplementation):
             if self.run_config.get('endpoint') is not None 
             else 'http://host.docker.internal:11434/api/chat'
         )
+        # TODO: identify fix for this. Refer Issue #38
+        if 'localhost' in self.ollama_server_endpoint:
+            self.ollama_server_endpoint = self.ollama_server_endpoint.replace(
+                'localhost', 'host.docker.internal'
+            )
+        self.chat_memory:BaseMemory = ChatMemory().initialize(
+            memory_type=self.run_config.get('chat_memory'),
+            block_uuid=run_config['block_uuid']
+        )
         self.available_tools = {}
         self.request_payload = self.create_payload_from_run_config()
     
     def run(self, input_:dict) -> dict:
         self.request_payload['messages'] = []
-        self.request_payload['messages'].append(self.insert_system_message())
         
         # Create prompt
         parse_input = PromptTemplate(
@@ -71,7 +102,18 @@ class OllamaServerChat(BaseImplementation):
         
         # Flag to determine if a function is available to be called
         make_function_call = False
-        self.request_payload['messages'].append({"role": "user", "content": prompt_template})
+        
+        self.request_payload['messages'] = self.chat_memory.get(
+            user_prompt={
+                'role': 'user',
+                'content': prompt_template
+            }
+        )
+        self.request_payload['messages'] = (
+            [self.insert_system_message()] + 
+            self.request_payload['messages']
+        )
+
         headers = {
             'Content-Type': 'application/json'
         }
@@ -83,6 +125,9 @@ class OllamaServerChat(BaseImplementation):
         )
         response = response.json()
         self.request_payload['messages'].append(response['message'])
+        self.chat_memory.put(
+            messages=self.request_payload['messages']
+        )
         
         messages = self.request_payload['messages'][1:]
         response['conversation'] = messages
@@ -108,6 +153,9 @@ class OllamaServerChat(BaseImplementation):
                     "role": "tool",
                     "content": str(function_response)
                 })
+                self.chat_memory.put(
+                    messages=self.request_payload['messages']
+                )
         # If no functions were available for the tools, simply return the response
         if not make_function_call:
             return json.loads(json.dumps(response))
@@ -118,6 +166,9 @@ class OllamaServerChat(BaseImplementation):
         )
         response = response.json()
         self.request_payload['messages'].append(response['message'])
+        self.chat_memory.put(
+            messages=self.request_payload['messages']
+        )
         
         messages = self.request_payload['messages'][1:]
         response['conversation'] = messages

--- a/lib/otto_backend/implementations/tasks/ollama/ollama_server_generate.py
+++ b/lib/otto_backend/implementations/tasks/ollama/ollama_server_generate.py
@@ -12,10 +12,30 @@ class OllamaServerGenarate(BaseImplementation):
     display_name = 'Ollama Generate'
     block_type = 'process'
     block_metadata = BlockMetadata([
-        Field(name="model", display_name="Model", is_run_config=True, default_value='llama3'),
-        Field(name="endpoint", display_name="Endpoint", is_run_config=True, show_in_ui=False),
-        Field(name="system", display_name="System Message", is_run_config=True, show_in_ui=False),
-        Field(name="prompt", display_name="Prompt Template", is_run_config=True, show_in_ui=False),
+        Field(
+            name="model", 
+            display_name="Model", 
+            is_run_config=True, 
+            default_value='llama3'
+        ),
+        Field(
+            name="endpoint", 
+            display_name="Endpoint", 
+            is_run_config=True, 
+            show_in_ui=False
+        ),
+        Field(
+            name="system", 
+            display_name="System Message", 
+            is_run_config=True, 
+            show_in_ui=False
+        ),
+        Field(
+            name="prompt", 
+            display_name="Prompt Template", 
+            is_run_config=True, 
+            show_in_ui=False
+        ),
     ])
     
     def __init__(self, run_config:dict) -> None:

--- a/lib/otto_backend/implementations/tasks/openai/openai_chat.py
+++ b/lib/otto_backend/implementations/tasks/openai/openai_chat.py
@@ -19,11 +19,41 @@ class OpenAIChat(BaseImplementation):
     display_name = 'OpenAI Chat Completion'
     block_type = 'process'
     block_metadata = BlockMetadata([
-        Field(name="model", display_name="Model", is_run_config=True, default_value='gpt-4o-mini'),
-        Field(name="openai_api_key", display_name="API Key", is_run_config=True, show_in_ui=False, type=FieldType.PASSWORD.value),
-        Field(name="system", display_name="System Message", is_run_config=True, show_in_ui=False, type=FieldType.TEXTAREA.value),
-        Field(name="prompt_template", display_name="Prompt Template", is_run_config=True, show_in_ui=False, type=FieldType.PROMPT_TEMPLATE.value),
-        Field(name="tools", display_name="Tools", is_run_config=True, default_value=[], show_in_ui=False, type=FieldType.TOOL_LIST.value),
+        Field(
+            name="model", 
+            display_name="Model", 
+            is_run_config=True, 
+            default_value='gpt-4o-mini'
+        ),
+        Field(
+            name="openai_api_key", 
+            display_name="API Key", 
+            is_run_config=True, 
+            show_in_ui=False, 
+            type=FieldType.PASSWORD.value
+        ),
+        Field(
+            name="system", 
+            display_name="System Message", 
+            is_run_config=True, 
+            show_in_ui=False, 
+            type=FieldType.TEXTAREA.value
+        ),
+        Field(
+            name="prompt_template", 
+            display_name="Prompt Template", 
+            is_run_config=True, 
+            show_in_ui=False, 
+            type=FieldType.PROMPT_TEMPLATE.value
+        ),
+        Field(
+            name="tools", 
+            display_name="Tools", 
+            is_run_config=True, 
+            default_value=[], 
+            show_in_ui=False, 
+            type=FieldType.TOOL_LIST.value
+        ),
     ])
     
     def __init__(self, run_config:dict) -> None:

--- a/lib/otto_backend/implementations/tasks/openai/openai_chat.py
+++ b/lib/otto_backend/implementations/tasks/openai/openai_chat.py
@@ -14,6 +14,7 @@ from implementations.base import (
 from extensions.llm_tools.openai_tool import OpenAITool
 from extensions.llm_memory.types import LLMChatMemoryType
 from extensions.llm_memory.chat_memory import ChatMemory
+from extensions.llm_memory.base import BaseMemory
 from core.input_parser.prompt_template import PromptTemplate
 
 
@@ -85,7 +86,7 @@ class OpenAIChat(BaseImplementation):
         self.openAI_client = OpenAI(
             api_key=self.run_config.get('openai_api_key'),
         )
-        self.chat_memory = ChatMemory.initialize(
+        self.chat_memory:BaseMemory = ChatMemory().initialize(
             memory_type=run_config.get('chat_memory'),
             block_uuid=run_config['block_uuid']
         )
@@ -98,7 +99,6 @@ class OpenAIChat(BaseImplementation):
     
     def run(self, input_:dict) -> dict:
         messages = []
-        messages.append(self.insert_system_message())
         
         # Create prompt
         parse_input = PromptTemplate(
@@ -109,7 +109,13 @@ class OpenAIChat(BaseImplementation):
         
         # Flag to determine if a function is available to be called
         make_function_call = False
-        messages.append({"role": "user", "content": prompt_template})
+        messages = self.chat_memory.get(
+            user_prompt={
+                'role': 'user',
+                'content': prompt_template
+            }
+        )
+        messages = [self.insert_system_message()] + messages
 
         # Make the first call.
         response = self.openAI_client.chat.completions.create(
@@ -124,6 +130,8 @@ class OpenAIChat(BaseImplementation):
                 response_choice=choice
             )
         )
+        self.chat_memory.put(messages)
+        
         response['conversation'] = messages[1:]
         # If model chose not to call any tools, return the response
         if not choice['message'].get('tool_calls'):
@@ -147,6 +155,7 @@ class OpenAIChat(BaseImplementation):
                     "content": str(function_response),
                     "tool_call_id": tool_call['id']
                 })
+                self.chat_memory.put(messages)
         # If no functions were available for the tools, simply return the response
         if not make_function_call:
             return json.loads(json.dumps(response))
@@ -163,6 +172,7 @@ class OpenAIChat(BaseImplementation):
                 response_choice=choice
             )
         )
+        self.chat_memory.put(messages)
 
         response['conversation'] = messages[1:]
         return json.loads(json.dumps(response))

--- a/lib/otto_backend/implementations/tasks/openai/openai_chat.py
+++ b/lib/otto_backend/implementations/tasks/openai/openai_chat.py
@@ -40,12 +40,12 @@ class OpenAIChat(BaseImplementation):
             display_name="Memory",
             is_run_config=True,
             show_in_ui=False,
-            default_value=None,
+            default_value='',
             type=FieldType.STATIC_DROPDOWN.value,
             metadata={
                 "dropdown_options": [
                     StaticDropdownOption(
-                        label="No Memory", value=None
+                        label="No Memory", value=''
                     ).__dict__,
                     StaticDropdownOption(
                         label="Basic Memory", value=LLMChatMemoryType.BASIC_MEMORY.value

--- a/lib/otto_backend/routers/auth_router.py
+++ b/lib/otto_backend/routers/auth_router.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from db.db_engine import get_db
 from db.models.users import Users
 from db.auth import authenticate_user, hash_password, create_token
-from routers.dependency import redis_client, get_current_user
+from routers.dependency import get_current_user
 
 router = APIRouter()
 

--- a/lib/otto_backend/routers/auth_router.py
+++ b/lib/otto_backend/routers/auth_router.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from db.db_engine import get_db
 from db.models.users import Users
 from db.auth import authenticate_user, hash_password, create_token
-from routers.dependency import token_store, get_current_user
+from routers.dependency import redis_client, get_current_user
 
 router = APIRouter()
 

--- a/lib/otto_backend/routers/dependency.py
+++ b/lib/otto_backend/routers/dependency.py
@@ -8,11 +8,10 @@ from redis import Redis
 from db.db_engine import get_db
 from db.models.users import Users
 
+from core.connections import redis_client
+
 # OAuth2 scheme for token-based authentication
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
-
-# Redis connection
-redis_client = Redis(host="redis", port=6379, decode_responses=True)
 
 def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> Users:
     """Retrieve the current user based on the token."""

--- a/lib/otto_backend/routers/dependency.py
+++ b/lib/otto_backend/routers/dependency.py
@@ -12,11 +12,11 @@ from db.models.users import Users
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
 
 # Redis connection
-token_store = Redis(host="redis", port=6379, decode_responses=True)
+redis_client = Redis(host="redis", port=6379, decode_responses=True)
 
 def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> Users:
     """Retrieve the current user based on the token."""
-    data = token_store.hgetall(f"tokens:{token}")
+    data = redis_client.hgetall(f"tokens:{token}")
     if not data:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token")
     

--- a/lib/otto_backend/routers/gcloud_router.py
+++ b/lib/otto_backend/routers/gcloud_router.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter
 from fastapi import Request, Depends, HTTPException, Response
 from fastapi.responses import RedirectResponse, HTMLResponse
 
-from routers.dependency import redis_client
+from core.connections import redis_client
 from google_auth_oauthlib.flow import Flow
 from integrations.gcloud.auth_flow import get_credentials, create_credential_file
 

--- a/lib/otto_backend/routers/gcloud_router.py
+++ b/lib/otto_backend/routers/gcloud_router.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter
 from fastapi import Request, Depends, HTTPException, Response
 from fastapi.responses import RedirectResponse, HTMLResponse
 
-from routers.dependency import token_store
+from routers.dependency import redis_client
 from google_auth_oauthlib.flow import Flow
 from integrations.gcloud.auth_flow import get_credentials, create_credential_file
 
@@ -45,14 +45,14 @@ async def login(request: GCloudLoginRequest):
     state_token = str(uuid.uuid4())
     redis_key = f"tokens:{state_token}"
     # Store in redis
-    token_store.hset(
+    redis_client.hset(
         name=redis_key, 
         mapping={
             "service": service,
             "scopes": json.dumps(scopes)
         }
     )
-    token_store.expire(redis_key, 3600)
+    redis_client.expire(redis_key, 3600)
     
     flow = Flow.from_client_secrets_file(CLIENT_SECRET_FILE, scopes, redirect_uri="http://localhost:8000/gcloud/auth/callback")
     auth_url, _ = flow.authorization_url(prompt="consent", state=redis_key)
@@ -72,7 +72,7 @@ async def auth_callback(code: str, state: Optional[str] = None):
         raise HTTPException(status_code=400, detail="Missing state parameter")
 
     # Get tokens
-    auth_state = token_store.hgetall(state)
+    auth_state = redis_client.hgetall(state)
     service, scopes = auth_state["service"], json.loads(auth_state["scopes"])
     
     flow = Flow.from_client_secrets_file(CLIENT_SECRET_FILE, scopes, redirect_uri="http://localhost:8000/gcloud/auth/callback")


### PR DESCRIPTION
This PR adds memory support for LLM blocks. As a starter, this PR only introduces a basic memory mechanism which means that all the interactions with the LLM is stored. The downside to this is that as the context window or the conversation length increases, we will eventually hit the LLM's context window. 

For storage, we utilize the redis server that we have when launching otto-m8. 